### PR TITLE
fix: add <forkCount>0</forkCount> to the config of surefire plugin to…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,7 @@
                     <argLine>
                         -javaagent:"${settings.localRepository}/org/aspectj/aspectjweaver/${aspectj.version}/aspectjweaver-${aspectj.version}.jar"
                     </argLine>
+                    <forkCount>0</forkCount>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
… try and fix the CI error: "Error occured in starting fork, check output in log"